### PR TITLE
Fix broken python build

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -10,7 +10,7 @@ else:
 if platform == "darwin":
     # To ensure gnu+11 and all std libs
     compile_args.append("-mmacosx-version-min=10.9")
-    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
+#    os.environ["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
 
 XBART_cpp_module = Extension('_xbart_cpp_',
                              sources=['xbart/xbart_wrap.cxx', 'xbart/xbart.cpp',
@@ -36,7 +36,7 @@ setup(name='xbart',
       version='0.1.7',
       author="Jingyu He, Saar Yalov, P. Richard Hahn",
       description="""XBART project""",
-      long_descripition=readme(),
+      long_description=readme(),
       include_dirs=[numpy.get_include(), '.', "src", "xbart"],
       ext_modules=[XBART_cpp_module],
       install_requires=['numpy'],

--- a/src/mcmc_loop.cpp
+++ b/src/mcmc_loop.cpp
@@ -165,11 +165,24 @@ void mcmc_loop_clt(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sig
 }
 
 void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,
-                           vector<vector<tree>> &trees, double no_split_penality,
+                           vector<vector<tree>> &trees, double no_split_penalty,
                            std::unique_ptr<State> &state, LogitModel *model,
                            std::unique_ptr<X_struct> &x_struct, std::vector< std::vector<double> > &phi_samples)
 {
+  mcmc_loop_multinomial(Xorder_std, verbose, trees, no_split_penalty, state, model, x_struct);
 
+    for (size_t sweeps = 0; sweeps < state->num_sweeps; sweeps++)
+      for (size_t tree_ind = 0; tree_ind < state->num_trees; tree_ind++)
+	for(size_t kk = 0; kk < Xorder_std[0].size(); kk++)
+	  phi_samples[sweeps * state->num_trees + tree_ind][kk] = (*(model->phi))[kk];
+	
+}
+
+void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,
+                           vector<vector<tree>> &trees, double no_split_penality,
+                           std::unique_ptr<State> &state, LogitModel *model,
+                           std::unique_ptr<X_struct> &x_struct)
+{
     if (state->parallel)
         thread_pool.start();
 
@@ -228,9 +241,9 @@ void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,
             
             model->state_sweep(tree_ind, state->num_trees, state->residual_std, x_struct);
             
-            for(size_t kk = 0; kk < Xorder_std[0].size(); kk ++ ){
-                phi_samples[sweeps * state->num_trees + tree_ind][kk] = (*(model->phi))[kk];
-            }     
+            // for(size_t kk = 0; kk < Xorder_std[0].size(); kk ++ ){
+            //     phi_samples[sweeps * state->num_trees + tree_ind][kk] = (*(model->phi))[kk];
+            // }     
             
         }
     }

--- a/src/mcmc_loop.cpp
+++ b/src/mcmc_loop.cpp
@@ -169,13 +169,71 @@ void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,
                            std::unique_ptr<State> &state, LogitModel *model,
                            std::unique_ptr<X_struct> &x_struct, std::vector< std::vector<double> > &phi_samples)
 {
-  mcmc_loop_multinomial(Xorder_std, verbose, trees, no_split_penalty, state, model, x_struct);
+    if (state->parallel)
+        thread_pool.start();
+
+    // Residual for 0th tree
+    // state->residual_std = *state->y_std - state->yhat_std + state->predictions_std[0];
+    model->ini_residual_std(state);
 
     for (size_t sweeps = 0; sweeps < state->num_sweeps; sweeps++)
-      for (size_t tree_ind = 0; tree_ind < state->num_trees; tree_ind++)
-	for(size_t kk = 0; kk < Xorder_std[0].size(); kk++)
-	  phi_samples[sweeps * state->num_trees + tree_ind][kk] = (*(model->phi))[kk];
-	
+    {
+
+        if (verbose == true)
+        {
+            COUT << "--------------------------------" << endl;
+            COUT << "number of sweeps " << sweeps << endl;
+            COUT << "--------------------------------" << endl;
+        }
+
+        for (size_t tree_ind = 0; tree_ind < state->num_trees; tree_ind++)
+        {
+
+            if (verbose)
+            {
+                cout << "sweep " << sweeps << " tree " << tree_ind << endl;
+            }
+            // Draw latents -- do last?
+
+            //Rcpp::Rcout << "Updating state";
+
+
+            if (state->use_all && (sweeps > state->burnin) && (state->mtry != state->p))
+            {
+                state->use_all = false;
+            }
+
+            // clear counts of splits for one tree
+            std::fill(state->split_count_current_tree.begin(), state->split_count_current_tree.end(), 0.0);
+
+            // subtract old tree for sampling case
+            if (state->sample_weights_flag)
+            {
+                state->mtry_weight_current_tree = state->mtry_weight_current_tree - state->split_count_all_tree[tree_ind];
+            }
+
+            model->initialize_root_suffstat(state, trees[sweeps][tree_ind].suff_stat);
+
+            //cout << trees[sweeps][tree_ind].suff_stat << endl;
+            
+            trees[sweeps][tree_ind].theta_vector.resize(model->dim_residual);
+
+            trees[sweeps][tree_ind].grow_from_root(state, Xorder_std, x_struct->X_counts, x_struct->X_num_unique, model, x_struct, sweeps, tree_ind, true, false, true);
+
+            state->update_split_counts(tree_ind);
+
+            // update partial fits for the next tree
+            model->update_state(state, tree_ind, x_struct);
+            
+            model->state_sweep(tree_ind, state->num_trees, state->residual_std, x_struct);
+            
+            for(size_t kk = 0; kk < Xorder_std[0].size(); kk ++ ){
+                phi_samples[sweeps * state->num_trees + tree_ind][kk] = (*(model->phi))[kk];
+            }     
+            
+        }
+    }
+    thread_pool.stop();  
 }
 
 void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,

--- a/src/mcmc_loop.cpp
+++ b/src/mcmc_loop.cpp
@@ -1,7 +1,7 @@
 #include "mcmc_loop.h"
 
 
-void mcmc_loop(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct)
+void mcmc_loop(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct)
 {
 
     if (state->parallel)
@@ -98,7 +98,7 @@ void mcmc_loop(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_d
 //     return;
 // }
 
-void mcmc_loop_clt(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, CLTClass *model, std::unique_ptr<X_struct> &x_struct)
+void mcmc_loop_clt(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, CLTClass *model, std::unique_ptr<X_struct> &x_struct)
 {
     // if (state->parallel)
     //     thread_pool.start();
@@ -237,7 +237,7 @@ void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,
 }
 
 void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,
-                           vector<vector<tree>> &trees, double no_split_penality,
+                           vector<vector<tree>> &trees, double no_split_penalty,
                            std::unique_ptr<State> &state, LogitModel *model,
                            std::unique_ptr<X_struct> &x_struct)
 {
@@ -308,7 +308,7 @@ void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose,
     thread_pool.stop();
 }
 
-void mcmc_loop_probit(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, ProbitClass *model, std::unique_ptr<X_struct> &x_struct)
+void mcmc_loop_probit(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, ProbitClass *model, std::unique_ptr<X_struct> &x_struct)
 {
 
     if (state->parallel)
@@ -360,7 +360,7 @@ void mcmc_loop_probit(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &
     thread_pool.stop();
 }
 
-// void mcmc_loop_MH(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct, std::vector<double> &accept_count, std::vector<double> &MH_vector, std::vector<double> &P_ratio, std::vector<double> &Q_ratio, std::vector<double> &prior_ratio)
+// void mcmc_loop_MH(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct, std::vector<double> &accept_count, std::vector<double> &MH_vector, std::vector<double> &P_ratio, std::vector<double> &Q_ratio, std::vector<double> &prior_ratio)
 // {
 
 //     if (state->parallel)
@@ -559,7 +559,7 @@ void mcmc_loop_probit(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &
 //     delete model;
 // }
 
-// void mcmc_loop_MH(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct, std::vector<double> &accept_count, std::vector<double> &MH_vector, std::vector<double> &P_ratio, std::vector<double> &Q_ratio, std::vector<double> &prior_ratio)
+// void mcmc_loop_MH(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct, std::vector<double> &accept_count, std::vector<double> &MH_vector, std::vector<double> &P_ratio, std::vector<double> &Q_ratio, std::vector<double> &prior_ratio)
 // {
 
 //     if (state->parallel)

--- a/src/mcmc_loop.h
+++ b/src/mcmc_loop.h
@@ -16,6 +16,7 @@ void mcmc_loop(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_d
 void mcmc_loop_clt(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, CLTClass *model, std::unique_ptr<X_struct> &x_struct);
 
 void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, LogitModel *model, std::unique_ptr<X_struct> &x_struct, std::vector< std::vector<double> > & phi_samples);
+void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, LogitModel *model, std::unique_ptr<X_struct> &x_struct);
 
 void mcmc_loop_probit(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, ProbitClass *model, std::unique_ptr<X_struct> &x_struct);
 

--- a/src/mcmc_loop.h
+++ b/src/mcmc_loop.h
@@ -9,15 +9,15 @@
 #include "X_struct.h"
 //#include "MH.h"
 
-void mcmc_loop(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct);
+void mcmc_loop(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct);
 
 // void predict_std_multinomial(const double *Xtestpointer, size_t N_test, size_t p, size_t num_trees, size_t num_sweeps, matrix<double> &yhats_test_xinfo, vector<vector<tree>> &trees);
 
-void mcmc_loop_clt(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, CLTClass *model, std::unique_ptr<X_struct> &x_struct);
+void mcmc_loop_clt(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, CLTClass *model, std::unique_ptr<X_struct> &x_struct);
 
-void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, LogitModel *model, std::unique_ptr<X_struct> &x_struct, std::vector< std::vector<double> > & phi_samples);
-void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, LogitModel *model, std::unique_ptr<X_struct> &x_struct);
+void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, LogitModel *model, std::unique_ptr<X_struct> &x_struct, std::vector< std::vector<double> > & phi_samples);
+void mcmc_loop_multinomial(matrix<size_t> &Xorder_std, bool verbose, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, LogitModel *model, std::unique_ptr<X_struct> &x_struct);
 
-void mcmc_loop_probit(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, ProbitClass *model, std::unique_ptr<X_struct> &x_struct);
+void mcmc_loop_probit(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, ProbitClass *model, std::unique_ptr<X_struct> &x_struct);
 
-//void mcmc_loop_MH(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penality, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct, std::vector<double> &accept_count, std::vector<double> &MH_vector, std::vector<double> &P_ratio, std::vector<double> &Q_ratio, std::vector<double> &prior_ratio);
+//void mcmc_loop_MH(matrix<size_t> &Xorder_std, bool verbose, matrix<double> &sigma_draw_xinfo, vector<vector<tree>> &trees, double no_split_penalty, std::unique_ptr<State> &state, NormalModel *model, std::unique_ptr<X_struct> &x_struct, std::vector<double> &accept_count, std::vector<double> &MH_vector, std::vector<double> &P_ratio, std::vector<double> &Q_ratio, std::vector<double> &prior_ratio);


### PR DESCRIPTION
Fixing python build 

I was trying to use the python XBART today and discovered that the version on pypi seems to be broken.  So I cloned the repo and the build script there too was broken. So this PR is a quick and dirty fix to get a working python xbart.  Feel free to decline, or commandeer, or whatever you like.  

* remove the macosx_deployment_target variable, this seems to break installation for versions newer than 10.9
* fix the long_description typo in setup.py so that doesn't error on install
* mcmc_loop_multinomial is called with 7 and 8 arguments in different places, but only defined in mcmc_loop.h with 8 arguments.  This makes the 7-argument call in xbart.cpp error on compile.  This PR overloads the function to make the 8th phi_samples arguments argument optional
* duplicate the mcmc_loop_multinomial function so that the 8-argument version logs phi_samples and the 7 argument version doesn't.  The copy pasta is bad, but I'm not sure which one you prefer. 
* fix spelling of penalty from penality.  

With these changes, python/build_py.sh completes now with warnings but no errors, and import xbart loads the module successfully.